### PR TITLE
chore: align workload contract and bump lib-chart to v0.0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Configure your chart via `values.yaml`. See [libChart/values.yaml](libChart/valu
 Workload selection:
 - `workload.type` is required.
 - Supported values are `deployment` and `cronJob`.
+- All workload-specific settings live under `workload.spec`.
+- Top-level `deployment` / `cronJob` values blocks are not part of the supported contract and are rejected by schema validation.
 - Kubernetes compatibility target is `>=1.30`.
 
 Notable deployment networking option:

--- a/libChart/Chart.yaml
+++ b/libChart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lib-chart
 description: Unified Helm library chart for application deployment (Deployment, Services, Ingress, Monitoring, Persistence)
 type: library
-version: 0.0.13
-appVersion: "0.0.13"
+version: 0.0.14
+appVersion: "0.0.14"
 keywords:
   - application
   - deployment

--- a/libChart/values.schema.json
+++ b/libChart/values.schema.json
@@ -86,7 +86,7 @@
         },
         "spec": {
           "type": "object",
-          "description": "Workload specification for selected workload.type"
+          "description": "Workload specification for selected workload.type; all workload-specific settings live here and top-level deployment/cronJob blocks are rejected"
         }
       }
     },
@@ -94,7 +94,7 @@
     "deployment": {
       "title": "Deployment",
       "type": "object",
-      "description": "Deployment configuration",
+      "description": "Internal schema definition for workload.spec when workload.type=deployment; not a supported top-level values key",
       "additionalProperties": false,
       "properties": {
         "replicas": {
@@ -374,7 +374,7 @@
     "cronJob": {
       "title": "CronJob",
       "type": "object",
-      "description": "CronJob configuration for batch workloads",
+      "description": "Internal schema definition for workload.spec when workload.type=cronJob; not a supported top-level values key",
       "additionalProperties": false,
       "properties": {
         "nameOverride": {

--- a/libChart/values.yaml
+++ b/libChart/values.yaml
@@ -30,6 +30,8 @@ workload:
   # Supported values: deployment, cronJob
   type: deployment
   # spec contains workload-type-specific settings.
+  # All workload-specific settings belong under workload.spec.
+  # Top-level deployment/cronJob blocks are not part of the supported values contract.
   # For workload.type=deployment use Deployment keys (replicas/strategy/containers/...).
   # For workload.type=cronJob use CronJob keys (schedule/concurrencyPolicy/restartPolicy/containers/...).
   # CronJob-specific examples:

--- a/test-chart/Chart.lock
+++ b/test-chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: lib-chart
   repository: file://../libChart
-  version: 0.0.13
-digest: sha256:91a3b86490b2f59c865f895380c0d7c4dd916e4143c5654cb7ffb802b0bbc9df
-generated: "2026-03-05T13:19:44.476781+02:00"
+  version: 0.0.14
+digest: sha256:3b9a88d951049a011be06291307b4933bb1026e7d33a5fab603b84dab0c716a4
+generated: "2026-05-03T13:59:10.914443+03:00"

--- a/test-chart/Chart.yaml
+++ b/test-chart/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: test-chart
 description: Test harness for libChart library (unit tests and validation)
 type: application
-version: 0.0.13
-appVersion: "0.0.13"
+version: 0.0.14
+appVersion: "0.0.14"
 dependencies:
   - name: lib-chart
-    version: 0.0.13
+    version: 0.0.14
     repository: file://../libChart
     # To use the published OCI chart:
     # repository: oci://ghcr.io/orhayoun-eevee/libchart

--- a/test-chart/tests/configmap_test.yaml
+++ b/test-chart/tests/configmap_test.yaml
@@ -8,13 +8,15 @@ tests:
       global:
         name: cfg-app
         namespace: cfg-ns
-      deployment:
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       configMap:
         componentLabel: app-config
         additionalLabels:

--- a/test-chart/tests/grafana_test.yaml
+++ b/test-chart/tests/grafana_test.yaml
@@ -8,13 +8,15 @@ tests:
       global:
         name: grafana-app
         namespace: monitor-ns
-      deployment:
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       metrics:
         enabled: true
         serviceMonitor:

--- a/test-chart/tests/httproute_test.yaml
+++ b/test-chart/tests/httproute_test.yaml
@@ -9,14 +9,16 @@ tests:
       global:
         name: test-app
         namespace: test-namespace
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       network:
         httpRoute:
           enabled: true
@@ -84,14 +86,16 @@ tests:
       global:
         name: multi-host-app
         namespace: test-namespace
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       network:
         httpRoute:
           enabled: true
@@ -134,14 +138,16 @@ tests:
       global:
         name: route-host-app
         namespace: test-namespace
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       network:
         httpRoute:
           enabled: true

--- a/test-chart/tests/istio_test.yaml
+++ b/test-chart/tests/istio_test.yaml
@@ -8,13 +8,15 @@ tests:
       global:
         name: istio-app
         namespace: istio-ns
-      deployment:
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       network:
         enabled: true
         istio:

--- a/test-chart/tests/labels_test.yaml
+++ b/test-chart/tests/labels_test.yaml
@@ -9,13 +9,15 @@ tests:
         namespace: test-namespace
         labels:
           partOf: media-center
-      deployment:
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
     asserts:
       - documentIndex: 0
         equal:
@@ -32,13 +34,15 @@ tests:
         namespace: test-namespace
         labels:
           component: global-component
-      deployment:
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
     asserts:
       - documentIndex: 0
         equal:
@@ -53,13 +57,15 @@ tests:
         chart:
           name: parent-chart
           version: 1.2.3
-      deployment:
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
     asserts:
       - documentIndex: 0
         equal:
@@ -73,13 +79,15 @@ tests:
         namespace: test-namespace
         chart:
           appVersion: 9.9.9
-      deployment:
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
     asserts:
       - documentIndex: 0
         equal:

--- a/test-chart/tests/observability_test.yaml
+++ b/test-chart/tests/observability_test.yaml
@@ -9,14 +9,16 @@ tests:
       global:
         name: sm-app
         namespace: monitor-ns
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       metrics:
         enabled: true
         serviceMonitor:
@@ -78,14 +80,16 @@ tests:
       global:
         name: port-app
         namespace: default
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       metrics:
         enabled: true
         serviceMonitor:
@@ -107,14 +111,16 @@ tests:
       global:
         name: auth-app
         namespace: default
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       metrics:
         enabled: true
         serviceMonitor:
@@ -161,14 +167,16 @@ tests:
       global:
         name: selector-app
         namespace: default
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: latest
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: latest
       metrics:
         enabled: true
         serviceMonitor:
@@ -192,14 +200,16 @@ tests:
       global:
         name: rule-app
         namespace: rule-ns
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       metrics:
         enabled: true
         serviceMonitor:

--- a/test-chart/tests/pdb_test.yaml
+++ b/test-chart/tests/pdb_test.yaml
@@ -8,13 +8,15 @@ tests:
       global:
         name: pdb-app
         namespace: pdb-ns
-      deployment:
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       podDisruptionBudget:
         enabled: true
         minAvailable: 0
@@ -43,13 +45,15 @@ tests:
       global:
         name: pdb-app
         namespace: pdb-ns
-      deployment:
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       podDisruptionBudget:
         enabled: true
         minAvailable: null

--- a/test-chart/tests/pvc_test.yaml
+++ b/test-chart/tests/pvc_test.yaml
@@ -9,14 +9,16 @@ tests:
       global:
         name: test-app
         namespace: test-namespace
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       persistence:
         enabled: true
         claims:
@@ -55,14 +57,16 @@ tests:
       global:
         name: pvc-app
         namespace: default
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: latest
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: latest
       persistence:
         enabled: true
         claims:

--- a/test-chart/tests/security_test.yaml
+++ b/test-chart/tests/security_test.yaml
@@ -9,14 +9,16 @@ tests:
       global:
         name: test-app
         namespace: test-namespace
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       serviceAccount:
         create: true
         name: custom-sa
@@ -44,14 +46,16 @@ tests:
       global:
         name: default-app
         namespace: default
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: latest
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: latest
       serviceAccount:
         create: true
     asserts:
@@ -69,14 +73,16 @@ tests:
       global:
         name: np-app
         namespace: np-ns
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       network:
         services:
           items:
@@ -144,14 +150,16 @@ tests:
       global:
         name: secret-app
         namespace: secret-ns
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       secrets:
         enabled: true
         sealedSecret:

--- a/test-chart/tests/service_test.yaml
+++ b/test-chart/tests/service_test.yaml
@@ -9,14 +9,16 @@ tests:
       global:
         name: test-app
         namespace: test-namespace
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       network:
         services:
           items:
@@ -63,14 +65,16 @@ tests:
       global:
         name: svc-app
         namespace: default
-      deployment:
-        replicas: 1
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: latest
+      workload:
+        type: deployment
+        spec:
+          replicas: 1
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: latest
       network:
         services:
           items:
@@ -103,13 +107,15 @@ tests:
       global:
         name: no-target-port-app
         namespace: default
-      deployment:
-        containers:
-          app:
-            enabled: true
-            image:
-              repository: nginx
-              tag: "1.25"
+      workload:
+        type: deployment
+        spec:
+          containers:
+            app:
+              enabled: true
+              image:
+                repository: nginx
+                tag: "1.25"
       network:
         services:
           items:

--- a/test-chart/tests/validation_test.yaml
+++ b/test-chart/tests/validation_test.yaml
@@ -2,6 +2,8 @@
 # Structural checks (types, patterns, conditional-required, minProperties) are enforced by
 # values.schema.json and tested via automated schema fail-case tests (make test-schema).
 # These tests cover only what schema cannot express:
+# Active forward-contract coverage uses workload.type/workload.spec.
+# Legacy top-level deployment/cronJob values belong only in explicit migration or deprecation coverage.
 #   - workload.spec (deployment): at least one enabled container (iteration logic)
 #   - workload.spec (cronJob): at least one enabled container + schedule/timezone guards
 #   - PDB: mutual exclusivity with zero-value awareness (index + ne nil)

--- a/test-chart/values.yaml
+++ b/test-chart/values.yaml
@@ -23,6 +23,8 @@ global:
 workload:
   # Supported values: deployment, cronJob
   type: deployment
+  # Keep workload-specific settings under workload.spec.
+  # Top-level deployment/cronJob blocks are rejected by the library schema.
   spec:
     replicas: 1
     strategy:

--- a/tests/schema-fail-cases/legacy-top-level-deployment.yaml
+++ b/tests/schema-fail-cases/legacy-top-level-deployment.yaml
@@ -1,0 +1,17 @@
+# Test: legacy top-level deployment block must be rejected
+global:
+  name: test-app
+  namespace: test-namespace
+
+workload:
+  type: deployment
+  spec:
+    containers:
+      app:
+        enabled: true
+        image:
+          repository: nginx
+          tag: "1.25"
+
+deployment:
+  replicas: 2

--- a/tests/snapshots/cronjob.yaml
+++ b/tests/snapshots/cronjob.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: test-release
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cron-app
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 automountServiceAccountToken: false
 ---
 # Source: test-chart/templates/all.yaml
@@ -25,8 +25,8 @@ metadata:
     app.kubernetes.io/instance: test-release
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cron-app
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 spec:
   schedule: "0 * * * *"
   concurrencyPolicy: Forbid
@@ -42,8 +42,8 @@ spec:
             app.kubernetes.io/instance: test-release
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: cron-app
-            app.kubernetes.io/version: 0.0.13
-            helm.sh/chart: test-chart-0.0.13
+            app.kubernetes.io/version: 0.0.14
+            helm.sh/chart: test-chart-0.0.14
         spec:
           
           terminationGracePeriodSeconds: 30

--- a/tests/snapshots/full.yaml
+++ b/tests/snapshots/full.yaml
@@ -11,8 +11,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: full-app
     app.kubernetes.io/part-of: test-suite
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 spec:
   podSelector:
     matchLabels:
@@ -48,8 +48,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: full-app
     app.kubernetes.io/part-of: test-suite
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 spec:
   selector:
     matchLabels:
@@ -70,8 +70,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: full-app
     app.kubernetes.io/part-of: test-suite
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
   annotations:
     test-annotation: full-scenario
 automountServiceAccountToken: false
@@ -88,8 +88,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: full-app
     app.kubernetes.io/part-of: test-suite
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 data:
   config.yaml: |
     environment: test
@@ -109,8 +109,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: full-app
     app.kubernetes.io/part-of: test-suite
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 spec:
   accessModes:
     - ReadWriteOnce
@@ -131,8 +131,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: full-app
     app.kubernetes.io/part-of: test-suite
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 spec:
   type: ClusterIP
   ports:
@@ -156,8 +156,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: full-app
     app.kubernetes.io/part-of: test-suite
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 spec:
   replicas: 2
   revisionHistoryLimit: 3
@@ -175,8 +175,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: full-app
         app.kubernetes.io/part-of: test-suite
-        app.kubernetes.io/version: 0.0.13
-        helm.sh/chart: test-chart-0.0.13
+        app.kubernetes.io/version: 0.0.14
+        helm.sh/chart: test-chart-0.0.14
         test-label: full-scenario
     spec:
       
@@ -270,8 +270,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: full-app
     app.kubernetes.io/part-of: test-suite
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 spec:
   groups:
     - name: full-app.rules
@@ -296,8 +296,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: full-app
     app.kubernetes.io/part-of: test-suite
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 spec:
   selector:
     matchLabels:

--- a/tests/snapshots/minimal.yaml
+++ b/tests/snapshots/minimal.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: test-release
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: test-app
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 automountServiceAccountToken: false
 ---
 # Source: test-chart/templates/all.yaml
@@ -25,8 +25,8 @@ metadata:
     app.kubernetes.io/instance: test-release
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: test-app
-    app.kubernetes.io/version: 0.0.13
-    helm.sh/chart: test-chart-0.0.13
+    app.kubernetes.io/version: 0.0.14
+    helm.sh/chart: test-chart-0.0.14
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -43,8 +43,8 @@ spec:
         app.kubernetes.io/instance: test-release
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
-        app.kubernetes.io/version: 0.0.13
-        helm.sh/chart: test-chart-0.0.13
+        app.kubernetes.io/version: 0.0.14
+        helm.sh/chart: test-chart-0.0.14
     spec:
       
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## Summary
- align active workload contract docs, comments, and schema wording
- lock legacy top-level deployment rejection with a schema fail-case
- bump lib-chart and test-chart to 0.0.14 with refreshed lockfile and snapshots

## Verification
- make -C helm-common-lib deps
- make -C helm-common-lib ci