### PR TITLE
ci: bump build-workflow to v0.1.26

### DIFF
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   publish-libchart:
     name: Publish libChart to GHCR
-    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.22
+    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.26
     with:
       chart_path: libChart
       release_environment: production

--- a/.github/workflows/pr-required-checks.yaml
+++ b/.github/workflows/pr-required-checks.yaml
@@ -33,7 +33,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.22
+    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.26
     with:
       chart_kind: lib
     secrets:

--- a/.github/workflows/renovate-config.yaml
+++ b/.github/workflows/renovate-config.yaml
@@ -21,4 +21,4 @@ concurrency:
 
 jobs:
   validate:
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.22
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.26


### PR DESCRIPTION
## Summary
- bump all build-workflow reusable workflow refs to v0.1.26
- pick up wrapper-validation and install-smoke fixes in the shared workflow release

## Validation
- GitHub PR required checks