### PR TITLE
ci: bump build-workflow refs to v0.1.28

### DIFF
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   publish-libchart:
     name: Publish libChart to GHCR
-    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.27
+    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.28
     with:
       chart_path: libChart
       release_environment: production

--- a/.github/workflows/pr-required-checks.yaml
+++ b/.github/workflows/pr-required-checks.yaml
@@ -33,7 +33,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.27
+    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.28
     with:
       chart_kind: lib
     secrets:

--- a/.github/workflows/renovate-config.yaml
+++ b/.github/workflows/renovate-config.yaml
@@ -21,4 +21,4 @@ concurrency:
 
 jobs:
   validate:
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.27
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.28


### PR DESCRIPTION
## Summary
- bump helm-common-lib shared workflow wrappers to build-workflow v0.1.28
- keep the change set ref-only across pr-required-checks, on-tag, and renovate-config
- preserve helm-common-lib scope boundaries by leaving snapshot wrapper behavior and renovate.json unchanged

## Verification
- scripts/chart-ci.sh helm-common-lib
