### PR TITLE
ci: bump build-workflow to v0.1.32

### DIFF
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   publish-libchart:
     name: Publish libChart to GHCR
-    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.31
+    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.32
     with:
       chart_path: libChart
       release_environment: production

--- a/.github/workflows/pr-required-checks.yaml
+++ b/.github/workflows/pr-required-checks.yaml
@@ -33,7 +33,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.31
+    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.32
     with:
       chart_kind: lib
     secrets:

--- a/.github/workflows/renovate-config.yaml
+++ b/.github/workflows/renovate-config.yaml
@@ -21,4 +21,4 @@ concurrency:
 
 jobs:
   validate:
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.31
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.32


### PR DESCRIPTION
## Summary
- update shared build-workflow reusable workflow refs to v0.1.32

## Validation
- build-workflow v0.1.32 publish run passed: https://github.com/orhayoun-eevee/build-workflow/actions/runs/25635806510
- local chart CI not run because local Docker daemon is unavailable; GitHub PR checks are the validation gate.